### PR TITLE
Use indexed value - this is a list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   port                 = var.port == "" ? var.engine == "aurora-postgresql" ? "5432" : "3306" : var.port
-  stored_creds         = var.db_creds_path == "" ? {} : jsondecode(data.aws_secretsmanager_secret_version.stored_db_creds.secret_string)
+  stored_creds         = var.db_creds_path == "" ? {} : jsondecode(data.aws_secretsmanager_secret_version.stored_db_creds[0].secret_string)
   master_password      = var.password == "" ? (var.db_creds_path == "" ? element(concat(random_password.master_password.*.result, [""]), 0) : local.stored_creds.password) : var.password
   db_subnet_group_name = var.db_subnet_group_name == "" ? join("", aws_db_subnet_group.this.*.name) : var.db_subnet_group_name
   backtrack_window     = (var.engine == "aurora-mysql" || var.engine == "aurora") && var.engine_mode != "serverless" ? var.backtrack_window : 0


### PR DESCRIPTION
When not providing a credentials file to the module, the following error was observed:

```shell
❯ terraform plan

Error: Missing resource instance key

  on .terraform/modules/db/main.tf line 3, in locals:
   3:   stored_creds         = var.db_creds_path == "" ? {} : jsondecode(data.aws_secretsmanager_secret_version.stored_db_creds.secret_string)

Because data.aws_secretsmanager_secret_version.stored_db_creds has "count"
set, its attributes must be accessed on specific instances.

For example, to correlate with indices of a referring resource, use:
    data.aws_secretsmanager_secret_version.stored_db_creds[count.index]
```

This will fix it.