### PR TITLE
Ensure no disallowed special characters in pass

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ resource "random_password" "master_password" {
 
   length  = 24
   special = true
+  override_special = "!#$%&*()-_=+[]{}<>:?" # Must not contain any of `/'"@` as per AWS RDS password rules
 }
 
 data "aws_secretsmanager_secret_version" "stored_db_creds" {


### PR DESCRIPTION
The auto-generated RDS password for my cluster contained an `@`, ultimately resulting in the password not working. I realized when attempting to change it that there is a disallowed special characters list in rds passwords: `"'@/`. I've ensured that the disallowed special chars are not present in the password generated here.

`DB_PASS=ss!t7*5_gc}%@=SAZ?N:wD?c` 🤕 

![image](https://user-images.githubusercontent.com/191587/108602590-b24f3980-7370-11eb-805a-e34cb20d0271.png)
